### PR TITLE
Fixed a mistake in README.md controls section

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ $ ./jaibreak
 
 ## Controls
 
-- <kbd>←</kbd>/<kbd>→</kbd> — move bar left/right
-- <kbd>ESC</kbd> — toggle pause
+- <kbd>A</kbd>/<kbd>D</kbd> — move bar left/right
 - <kbd>SPACE</kbd> — release the "ball"
 
 ### Debug Build


### PR DESCRIPTION
1. In web version the <kbd>←</kbd>/<kbd>→</kbd> buttons don't do anything, instead <kbd>A</kbd>/<kbd>D</kbd> move the bar.
2. In web version <kbd>ESC</kbd> doesn't toggle anything.